### PR TITLE
Port to Intel x86_64 macOS (closes #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Used by [FindMySyncPlus](https://github.com/manonstreet/FindMySyncPlus) to decry
 
 ## Prerequisites
 
-- macOS (Apple Silicon only — Intel support is [planned](https://github.com/manonstreet/findmy-key-extractor/issues/2))
+- macOS (Apple Silicon **and** Intel x86_64; the lldb scripts dispatch on `target.GetTriple()`)
 - Xcode Command Line Tools — `xcode-select --install` (provides lldb)
 - Python 3 + pip
 - Find My app installed and signed into iCloud

--- a/extract.sh
+++ b/extract.sh
@@ -36,9 +36,13 @@ echo "  ────────────────────────
 echo ""
 echo "  ⏳  Extracting keys (~10s)..."
 
-# ── Kill everything ───────────────────────────────────────────────────────
+# ── Pre-kill stale lldb instances and FindMy.app (NOT findmylocateagent yet —
+#    we need lldb to be in --wait-for state BEFORE we kill it, otherwise
+#    launchd respawns it before lldb starts waiting and --wait-for never fires.
+#    `pkill lldb` matches by exec name, so it kills the lldb children of any
+#    `sudo lldb` wrappers; their sudo parents exit when the child dies.) ────
+sudo pkill -9 lldb 2>/dev/null || true
 pkill -9 FindMy 2>/dev/null || true
-sudo pkill -9 findmylocateagent 2>/dev/null || true
 sleep 0.5
 
 # ── Prepare output directory ─────────────────────────────────────────────
@@ -46,8 +50,7 @@ mkdir -p "$KEYS_DIR"
 rm -f "$KEYS_DIR"/LocalStorage.key
 rm -f "$KEYS_DIR"/*.bplist
 
-# ── Launch both lldb sessions in parallel ─────────────────────────────────
-
+# ── Launch both lldb sessions in parallel — they enter --wait-for state ───
 sudo lldb --wait-for -n findmylocateagent \
     -o "settings set frame-format ''" \
     -o "settings set auto-confirm true" \
@@ -64,8 +67,17 @@ sudo lldb --wait-for -n FindMy \
     -o "quit" > "$LOG2" 2>&1 &
 PID2=$!
 
-# ── Open Find My after a brief delay (triggers both processes) ────────────
-sleep 2
+# ── Give the lldb waiters a moment to install themselves ──────────────────
+sleep 1
+
+# ── NOW restart findmylocateagent via launchctl — `pkill -9` is unreliable
+#    here (the daemon survives SIGKILL on some configurations, possibly due
+#    to launchd protection or a stuck-zombie state). `kickstart -k` cleanly
+#    stops and restarts via launchd's own mechanism so the waiting lldb
+#    catches the fresh PID. The agent runs in the per-user GUI domain. ────
+USER_UID=$(id -u "$(stat -f %Su /dev/console)")
+sudo launchctl kickstart -k "gui/$USER_UID/com.apple.findmy.findmylocateagent" 2>/dev/null || true
+sleep 1
 open /System/Applications/FindMy.app
 
 # ── Wait for both lldb sessions to finish ─────────────────────────────────

--- a/extract_db_key.py
+++ b/extract_db_key.py
@@ -27,6 +27,18 @@ def _log(msg):
     print(msg, flush=True)
 
 
+def _is_x86(frame):
+    triple = frame.GetThread().GetProcess().GetTarget().GetTriple() or ""
+    return triple.startswith("x86_64")
+
+
+def _arg(frame, n):
+    """n-th integer/pointer argument under the platform C ABI."""
+    names = (["rdi", "rsi", "rdx", "rcx", "r8", "r9"] if _is_x86(frame)
+             else ["x0", "x1", "x2", "x3", "x4", "x5"])
+    return frame.FindRegister(names[n]).GetValueAsUnsigned()
+
+
 def _read_mem(process, ptr, size):
     if not ptr or size <= 0 or size > 65536:
         return None
@@ -67,9 +79,10 @@ def on_sqlite3_key_v2(frame, bp_loc, extra_args, internal_dict):
         return False
 
     process = frame.GetThread().GetProcess()
-    db_ptr  = frame.FindRegister("x0").GetValueAsUnsigned()
-    key_ptr = frame.FindRegister("x2").GetValueAsUnsigned()
-    key_len = frame.FindRegister("x3").GetValueAsUnsigned()
+    db_ptr  = _arg(frame, 0)
+    key_ptr = _arg(frame, 2)
+    key_len = _arg(frame, 3)
+    _log(f"  🔔  sqlite3_key_v2 hit: db=0x{db_ptr:x} key=0x{key_ptr:x} len={key_len}")
 
     if key_len != 32:
         return False
@@ -100,6 +113,9 @@ def __lldb_init_module(debugger, internal_dict):
         _log("  ❌  No valid target")
         return
 
+    triple = target.GetTriple() or "(unknown)"
+    _log(f"  📍  target triple: {triple}")
+
     _bp = target.BreakpointCreateByName("sqlite3_key_v2")
     _bp.SetScriptCallbackFunction("extract_db_key.on_sqlite3_key_v2")
-    _log("  ⏳  Intercepting sqlite3_key_v2...")
+    _log(f"  ⏳  Intercepting sqlite3_key_v2 (resolved {_bp.GetNumLocations()} locations)")

--- a/extract_keychain_keys.py
+++ b/extract_keychain_keys.py
@@ -35,6 +35,64 @@ def _log(msg):
     print(msg, flush=True)
 
 
+def _is_x86(frame):
+    triple = frame.GetThread().GetProcess().GetTarget().GetTriple() or ""
+    return triple.startswith("x86_64")
+
+
+def _arg(frame, n):
+    """n-th integer/pointer arg under the platform C ABI (System V AMD64 / AAPCS64)."""
+    names = (["rdi", "rsi", "rdx", "rcx", "r8", "r9"] if _is_x86(frame)
+             else ["x0", "x1", "x2", "x3", "x4", "x5"])
+    return frame.FindRegister(names[n]).GetValueAsUnsigned()
+
+
+def _retval_signed(frame):
+    """Integer return value, signed (for OSStatus etc)."""
+    name = "rax" if _is_x86(frame) else "x0"
+    return frame.FindRegister(name).GetValueAsSigned()
+
+
+def _entry_return_address(frame):
+    """At a function-entry breakpoint, the address the function will return to.
+
+    On ARM64 this is the link register `lr`. On x86_64 the `call` instruction
+    just pushed the return address, so it's at `*(uint64_t*)$rsp`.
+    """
+    if _is_x86(frame):
+        process = frame.GetThread().GetProcess()
+        rsp = frame.FindRegister("rsp").GetValueAsUnsigned()
+        if not rsp:
+            return 0
+        err = lldb.SBError()
+        data = process.ReadMemory(int(rsp), 8, err)
+        if err.Fail() or not data:
+            return 0
+        return struct.unpack("<Q", bytes(data))[0]
+    return frame.FindRegister("lr").GetValueAsUnsigned()
+
+
+def _callee_saved_candidates(frame):
+    """Callee-saved registers that may still hold a value the function set up."""
+    if _is_x86(frame):
+        # rbp is also callee-saved but is typically the frame pointer; skip it.
+        return ["rbx", "r12", "r13", "r14", "r15"]
+    return ["x19", "x20", "x21"]
+
+
+# ARM64e adds Pointer Authentication Codes in the high bits of pointers; mask
+# to the low 40 bits to recover the real address. On x86_64 there is no PAC,
+# AND user-space pointers can use up to 47 bits (the 0x7fff_xxxx_xxxx range
+# for Catalyst apps), so masking would corrupt them. Use _strip_pac everywhere
+# we previously hardcoded `& 0x000000FFFFFFFFFF`.
+
+_PAC_MASK = 0x000000FFFFFFFFFF
+
+
+def _strip_pac(frame, ptr):
+    return ptr if _is_x86(frame) else (ptr & _PAC_MASK)
+
+
 def _read_mem(process, ptr, size):
     if not ptr or size <= 0 or size > 65536:
         return None
@@ -66,9 +124,10 @@ def _on_sqlite3_key_v2(frame, bp_loc, extra_args, internal_dict):
         return False
 
     process = frame.GetThread().GetProcess()
-    db_ptr  = frame.FindRegister("x0").GetValueAsUnsigned()
-    key_ptr = frame.FindRegister("x2").GetValueAsUnsigned()
-    key_len = frame.FindRegister("x3").GetValueAsUnsigned()
+    db_ptr  = _arg(frame, 0)
+    key_ptr = _arg(frame, 2)
+    key_len = _arg(frame, 3)
+    _log(f"  🔔  sqlite3_key_v2 hit: db=0x{db_ptr:x} key=0x{key_ptr:x} len={key_len}")
 
     if key_len != 32:
         return False
@@ -119,10 +178,10 @@ def _on_secitem_entry(frame, bp_loc, extra_args, internal_dict):
         return False
 
     try:
-        result_out_ptr = frame.FindRegister("x1").GetValueAsUnsigned()
-        lr_raw = frame.FindRegister("lr").GetValueAsUnsigned()
-        # Strip PAC bits (arm64e pointer authentication) — keep low 40 bits
-        lr = lr_raw & 0x000000FFFFFFFFFF
+        result_out_ptr = _arg(frame, 1)
+        lr_raw = _entry_return_address(frame)
+        _log(f"  🔔  SecItemCopyMatching hit: result_out=0x{result_out_ptr:x} retaddr=0x{lr_raw:x}")
+        lr = _strip_pac(frame, lr_raw)
 
         if not result_out_ptr or not lr:
             return False
@@ -167,13 +226,14 @@ def _handle_secitem_return(frame):
     global _secitem_captured, _secitem_resolved
 
     pc = frame.GetPC()
-    queue = _pending_returns.get(pc) or _pending_returns.get(pc & 0x000000FFFFFFFFFF)
+    pc_stripped = _strip_pac(frame, pc)
+    queue = _pending_returns.get(pc) or _pending_returns.get(pc_stripped)
     if not queue:
         return False
 
     ctx = queue.pop(0)  # FIFO — oldest call returns first
     # Clean up empty queues so the BP can be removed
-    addr = pc if pc in _pending_returns else (pc & 0x000000FFFFFFFFFF)
+    addr = pc if pc in _pending_returns else pc_stripped
     if addr in _pending_returns and not _pending_returns[addr]:
         del _pending_returns[addr]
 
@@ -182,8 +242,8 @@ def _handle_secitem_return(frame):
     idx = ctx["index"]
     result_out_ptr = ctx["result_out_ptr"]
 
-    # x0 = OSStatus (0 = success)
-    status = frame.FindRegister("x0").GetValueAsSigned()
+    # Return register (x0/rax) holds OSStatus; 0 = success
+    status = _retval_signed(frame)
     if status != 0:
         return False
 
@@ -193,8 +253,7 @@ def _handle_secitem_return(frame):
         return _try_secitem_objc_dump(frame, process, idx)
 
     data_ptr = struct.unpack('<Q', ptr_bytes)[0]
-    # Strip PAC bits from the data pointer too
-    data_ptr = data_ptr & 0x000000FFFFFFFFFF
+    data_ptr = _strip_pac(frame, data_ptr)
     if not data_ptr:
         return False
 
@@ -203,12 +262,13 @@ def _handle_secitem_return(frame):
 
 def _try_secitem_objc_dump(frame, process, idx):
     """Fallback: try to find the result via ObjC expression eval."""
-    # Try x19-x21 — callee-saved registers that might hold the result pointer
-    for reg_name in ["x19", "x20", "x21"]:
+    # Try callee-saved registers that might still hold the result pointer.
+    # ARM64 AAPCS: x19-x21. System V AMD64: rbx, r12-r15.
+    for reg_name in _callee_saved_candidates(frame):
         reg = frame.FindRegister(reg_name)
         if not reg.IsValid():
             continue
-        candidate = reg.GetValueAsUnsigned() & 0x000000FFFFFFFFFF
+        candidate = _strip_pac(frame, reg.GetValueAsUnsigned())
         if candidate < 0x100000000:  # skip small values (not heap pointers)
             continue
         # Probe if it looks like a CFData/NSData
@@ -260,7 +320,7 @@ def _save_secitem_result(frame, process, idx, result_ptr):
 
 def _read_nsstring(frame, process, ptr, opts):
     """Read an NSString value from an ObjC pointer."""
-    ptr = ptr & 0x000000FFFFFFFFFF
+    ptr = _strip_pac(frame, ptr)
     if not ptr:
         return None
     r_str = frame.EvaluateExpression(
@@ -283,7 +343,7 @@ def _save_dict_result(frame, process, idx, dict_ptr, opts):
         r_attr = frame.EvaluateExpression(
             f'(id)[(NSDictionary *){dict_ptr} objectForKey:@"{attr}"]', opts)
         if not r_attr.GetError().Fail():
-            attr_ptr = r_attr.GetValueAsUnsigned() & 0x000000FFFFFFFFFF
+            attr_ptr = _strip_pac(frame, r_attr.GetValueAsUnsigned())
             if attr_ptr:
                 attr_val = _read_nsstring(frame, process, attr_ptr, opts)
                 if attr_val:
@@ -294,7 +354,7 @@ def _save_dict_result(frame, process, idx, dict_ptr, opts):
     r_data = frame.EvaluateExpression(
         f'(id)[(NSDictionary *){dict_ptr} objectForKey:@"v_Data"]', opts)
     if not r_data.GetError().Fail():
-        v_data_ptr = r_data.GetValueAsUnsigned() & 0x000000FFFFFFFFFF
+        v_data_ptr = _strip_pac(frame, r_data.GetValueAsUnsigned())
         if v_data_ptr:
             # Use service name for filename if available
             name = service_name if service_name else f"secitem_{idx}"
@@ -317,7 +377,7 @@ def _serialize_and_save(frame, process, idx, obj_ptr, opts):
         r_desc = frame.EvaluateExpression(
             f'(id)[(id){obj_ptr} description]', opts)
         if not r_desc.GetError().Fail():
-            desc_ptr = r_desc.GetValueAsUnsigned() & 0x000000FFFFFFFFFF
+            desc_ptr = _strip_pac(frame, r_desc.GetValueAsUnsigned())
             if desc_ptr:
                 desc = _read_cstring(process, desc_ptr, 4096)
                 if desc:
@@ -329,7 +389,7 @@ def _serialize_and_save(frame, process, idx, obj_ptr, opts):
                     return False
         return False
 
-    ser_ptr = r_ser.GetValueAsUnsigned() & 0x000000FFFFFFFFFF
+    ser_ptr = _strip_pac(frame, r_ser.GetValueAsUnsigned())
     if not ser_ptr:
         return False
 
@@ -391,10 +451,13 @@ def __lldb_init_module(debugger, internal_dict):
         _log("  ❌  No valid target")
         return
 
+    triple = target.GetTriple() or "(unknown)"
+    _log(f"  📍  target triple: {triple}")
+
     _bp_key_v2 = target.BreakpointCreateByName("sqlite3_key_v2")
     _bp_key_v2.SetScriptCallbackFunction("extract_keychain_keys._on_sqlite3_key_v2")
 
     _bp_secitem = target.BreakpointCreateByName("SecItemCopyMatching")
     _bp_secitem.SetScriptCallbackFunction("extract_keychain_keys._on_secitem_entry")
 
-    _log("  ⏳  Waiting for key derivation...")
+    _log(f"  ⏳  Waiting for key derivation... (sqlite3_key_v2: {_bp_key_v2.GetNumLocations()} locs, SecItemCopyMatching: {_bp_secitem.GetNumLocations()} locs)")

--- a/verify_key.py
+++ b/verify_key.py
@@ -17,6 +17,7 @@ Exit 0 on success, 1 on failure.
 
 import plistlib
 import struct
+import subprocess
 import sys
 from pathlib import Path
 
@@ -29,11 +30,38 @@ PAGE_SIZE    = 4096
 RESERVED_OFF = 4084
 SQLITE_MAGIC = b"SQLite format 3\x00"
 
-ENC_DB = (Path.home() /
-          "Library/Group Containers"
-          "/group.com.apple.findmy.findmylocateagent"
-          "/Library/Application Support"
-          "/LocalStorage.db")
+
+def _find_localstorage_db():
+    """Locate findmylocateagent's encrypted LocalStorage.db.
+
+    On recent macOS the agent stores its DB in DARWIN_USER_DIR (the per-user
+    confinement directory under /var/folders), not in the legacy
+    ~/Library/Group Containers location.
+    """
+    candidates = []
+    try:
+        darwin_user_dir = subprocess.run(
+            ["getconf", "DARWIN_USER_DIR"], capture_output=True, text=True, check=True
+        ).stdout.strip()
+        if darwin_user_dir:
+            candidates.append(
+                Path(darwin_user_dir)
+                / "com.apple.findmy.findmylocateagent" / "LocalStorage.db"
+            )
+    except Exception:
+        pass
+    candidates.append(
+        Path.home()
+        / "Library/Group Containers/group.com.apple.findmy.findmylocateagent"
+        / "Library/Application Support/LocalStorage.db"
+    )
+    for p in candidates:
+        if p.exists():
+            return p
+    return candidates[0]
+
+
+ENC_DB = _find_localstorage_db()
 
 
 def verify_localstorage_key(key_bytes, enc_db_path=ENC_DB):


### PR DESCRIPTION
Adds runtime architecture dispatch to the lldb scripts so the extractor works on Intel x86_64 macOS as well as Apple Silicon. Tested end-to-end on an Intel Mac mini running macOS 15.7.5; all three keys (LocalStorage.key, FMFDataManager.bplist, FMIPDataManager.bplist) verify cryptographically.

## What changed

### `extract_db_key.py` / `extract_keychain_keys.py` — x86_64 ABI dispatch

Previously the breakpoint handlers read function arguments out of ARM64 registers (`x0`, `x2`, `x3`, …) and treated the link register (`lr`) and a 40-bit pointer-authentication mask as universal. None of those apply on Intel macOS, so the scripts silently produced nothing on x86_64 — and on Catalyst apps in the `0x7fff_xxxx_xxxx` pointer range the legacy mask actively corrupted return-address breakpoints (FindMy.app reports its triple as `x86_64-apple-ios-macabi`).

Both scripts now branch on `target.GetTriple()`:

| Concept | ARM64 (AAPCS64) | x86_64 (System V AMD64) |
|---|---|---|
| Args 0–5 | `x0`–`x5` | `rdi`, `rsi`, `rdx`, `rcx`, `r8`, `r9` |
| Return value | `x0` | `rax` |
| Return address at function entry | `lr` | `*(uint64_t*)$rsp` (just pushed by `call`) |
| Callee-saved fallback | `x19`–`x21` | `rbx`, `r12`–`r15` |
| Pointer-auth strip | `& 0x000000FFFFFFFFFF` | passthrough — user pointers use up to 47 bits |

The same scripts continue to work unchanged on Apple Silicon. A few light diagnostic prints (target triple, breakpoint location count, per-hit pointer / length) make it easier to debug attach and symbol resolution without exposing key bytes.

### `extract.sh` — make `findmylocateagent` actually restart

Three race / kill issues that bit hard while testing on Intel but that can affect Apple Silicon too:

1. Stale `lldb --wait-for` instances from earlier failed runs survive across script invocations and keep their cached pre-fix Python module in their own interpreter, then race fresh lldbs for the respawned target. Adds `sudo pkill -9 lldb` at the top.

2. The original ordering pkill'd `findmylocateagent` *before* launching `lldb --wait-for`. launchd respawns the daemon inside that gap, so `--wait-for` sees no new instance and waits forever. Reordered: launch both lldb waiters first, sleep 1s so they actually install their listeners, *then* trigger the kill.

3. `pkill findmylocateagent` silently no-ops because the daemon name is 17 chars and `pkill` matches the 16-char-truncated `comm`. On at least some configurations the daemon also survives plain `kill -9` (likely a launchd protection / zombie state — observed PID surviving SIGKILL across many minutes). Replaced with `launchctl kickstart -k gui/<uid>/com.apple.findmy.findmylocateagent`, which routes through launchd's own stop+respawn path.

### `verify_key.py` — find LocalStorage.db on recent macOS

On macOS 15.7.5 (and likely earlier 14.x/15.x), `findmylocateagent` stores its encrypted SQLite databases under the per-user confinement directory at

```
$(getconf DARWIN_USER_DIR)/com.apple.findmy.findmylocateagent/LocalStorage.db
```

instead of `~/Library/Group Containers/group.com.apple.findmy.findmylocateagent/...`. `verify_key.py` now probes `DARWIN_USER_DIR` first and falls back to the legacy path for older systems. Without this fix the verify step fails with `Encrypted DB not found` even when the captured key is correct.

### `README.md`

Drops the "Apple Silicon only" qualifier from prerequisites now that the scripts dispatch on target triple.

## Test plan
- [x] Run `sudo ./extract.sh` on Intel macOS 15.7.5 — captures all three keys
- [x] `verify_key.py keys/LocalStorage.key` → ✅ verified [LocalStorage.db]
- [x] `verify_key.py keys/FMFDataManager.bplist` → ✅ verified [FriendCacheData.data]
- [x] `verify_key.py keys/FMIPDataManager.bplist` → ✅ verified [Devices.data]
- [ ] Re-test on Apple Silicon to confirm no regression — would appreciate a smoke test from a maintainer with an M-series Mac, since I only have Intel hardware available.