### PR TITLE
Fix extraction hang and missed LocalStorage key

### DIFF
--- a/extract.sh
+++ b/extract.sh
@@ -48,6 +48,7 @@ sleep 0.5
 # ── Prepare output directory ─────────────────────────────────────────────
 mkdir -p "$KEYS_DIR"
 rm -f "$KEYS_DIR"/LocalStorage.key
+rm -f "$KEYS_DIR"/LocalStorage.key.candidate
 rm -f "$KEYS_DIR"/*.bplist
 
 # ── Launch both lldb sessions in parallel — they enter --wait-for state ───

--- a/extract.sh
+++ b/extract.sh
@@ -55,16 +55,14 @@ sudo lldb --wait-for -n findmylocateagent \
     -o "settings set frame-format ''" \
     -o "settings set auto-confirm true" \
     -o "command script import $SCRIPT_DIR/extract_db_key.py" \
-    -o "c" \
-    -o "quit" > "$LOG1" 2>&1 &
+    -o "process continue" > "$LOG1" 2>&1 &
 PID1=$!
 
 sudo lldb --wait-for -n FindMy \
     -o "settings set frame-format ''" \
     -o "settings set auto-confirm true" \
     -o "command script import $SCRIPT_DIR/extract_keychain_keys.py" \
-    -o "c" \
-    -o "quit" > "$LOG2" 2>&1 &
+    -o "process continue" > "$LOG2" 2>&1 &
 PID2=$!
 
 # ── Give the lldb waiters a moment to install themselves ──────────────────
@@ -80,9 +78,34 @@ sudo launchctl kickstart -k "gui/$USER_UID/com.apple.findmy.findmylocateagent" 2
 sleep 1
 open /System/Applications/FindMy.app
 
-# ── Wait for both lldb sessions to finish ─────────────────────────────────
+# ── Wait up to 45s for keys (scripts kill targets when done) ──────────────
+for _ in $(seq 1 45); do
+    got=0
+    if [ -f "$KEYS_DIR/LocalStorage.key" ] || [ -f "$KEYS_DIR/LocalStorage.key.candidate" ]; then
+        got=$((got+1))
+    fi
+    [ -f "$KEYS_DIR/FMFDataManager.bplist" ] && got=$((got+1))
+    [ -f "$KEYS_DIR/FMIPDataManager.bplist" ] && got=$((got+1))
+    if [ "$got" -ge 3 ]; then
+        break
+    fi
+    # Also done if both lldb sessions exited
+    if ! kill -0 "$PID1" 2>/dev/null && ! kill -0 "$PID2" 2>/dev/null; then
+        break
+    fi
+    sleep 1
+done
+
+sudo kill -9 "$PID1" "$PID2" 2>/dev/null || true
 wait "$PID1" 2>/dev/null || true
 wait "$PID2" 2>/dev/null || true
+
+# Promote verified candidate if needed
+if [ ! -f "$KEYS_DIR/LocalStorage.key" ] && [ -f "$KEYS_DIR/LocalStorage.key.candidate" ]; then
+    if python3 "$SCRIPT_DIR/verify_key.py" "$KEYS_DIR/LocalStorage.key.candidate" >/dev/null 2>&1; then
+        mv "$KEYS_DIR/LocalStorage.key.candidate" "$KEYS_DIR/LocalStorage.key"
+    fi
+fi
 
 # ── Kill Find My, chown captured files ────────────────────────────────────
 pkill -9 FindMy 2>/dev/null || true

--- a/extract_db_key.py
+++ b/extract_db_key.py
@@ -95,22 +95,28 @@ def on_sqlite3_key_v2(frame, bp_loc, extra_args, internal_dict):
         _log("  ❌  Failed to read key from memory")
         return False
 
-    # Prefer LocalStorage; if path lookup fails, still save a candidate for verify.
+    # Prefer LocalStorage; if path lookup fails, retain the first candidate for
+    # verification but keep listening in case a confirmed LocalStorage hit
+    # arrives later.
     if db_path and "LocalStorage" in db_path:
         out = KEY_FILE
     elif not db_path:
         out = OUT_DIR / "LocalStorage.key.candidate"
+        if out.exists():
+            _log("  ⏭️  path lookup failed — candidate already saved")
+            return False
         _log("  ⚠️  path lookup failed — saving candidate for verification")
     else:
-        _log(f"  ⏭️  skipping non-LocalStorage db")
+        _log("  ⏭️  skipping non-LocalStorage db")
         return False
 
     with open(out, "wb") as f:
         f.write(key_data)
 
-    _done = True
     _log(f"  ✅  Captured key → {out.name}")
-    process.Kill()
+    if out == KEY_FILE:
+        _done = True
+        process.Kill()
     return False
 
 

--- a/extract_db_key.py
+++ b/extract_db_key.py
@@ -88,19 +88,28 @@ def on_sqlite3_key_v2(frame, bp_loc, extra_args, internal_dict):
         return False
 
     db_path = _get_db_path(frame, db_ptr)
-    if not db_path or "LocalStorage" not in db_path:
-        return False
+    _log(f"  📂  db_path={db_path!r}")
 
     key_data = _read_mem(process, key_ptr, 32)
     if not key_data:
         _log("  ❌  Failed to read key from memory")
         return False
 
-    with open(KEY_FILE, "wb") as f:
+    # Prefer LocalStorage; if path lookup fails, still save a candidate for verify.
+    if db_path and "LocalStorage" in db_path:
+        out = KEY_FILE
+    elif not db_path:
+        out = OUT_DIR / "LocalStorage.key.candidate"
+        _log("  ⚠️  path lookup failed — saving candidate for verification")
+    else:
+        _log(f"  ⏭️  skipping non-LocalStorage db")
+        return False
+
+    with open(out, "wb") as f:
         f.write(key_data)
 
     _done = True
-    _log(f"  ✅  Captured LocalStorage key → {KEY_FILE.name}")
+    _log(f"  ✅  Captured key → {out.name}")
     process.Kill()
     return False
 

--- a/extract_keychain_keys.py
+++ b/extract_keychain_keys.py
@@ -114,15 +114,42 @@ def _finish(process):
 
 # ── SecItemCopyMatching — capture all successful results ──────────────────
 
+def _query_service_name(frame, query_ptr):
+    """Read svce from the SecItemCopyMatching query dict (arg0)."""
+    if not query_ptr:
+        return None
+    opts = lldb.SBExpressionOptions()
+    opts.SetTimeoutInMicroSeconds(2_000_000)
+    opts.SetTryAllThreads(False)
+    opts.SetLanguage(lldb.eLanguageTypeObjC)
+    process = frame.GetThread().GetProcess()
+    query_ptr = _strip_pac(frame, query_ptr)
+    r = frame.EvaluateExpression(
+        f'(id)[(NSDictionary *){query_ptr} objectForKey:@"svce"]', opts)
+    if r.GetError().Fail():
+        return None
+    attr_ptr = _strip_pac(frame, r.GetValueAsUnsigned())
+    if not attr_ptr:
+        return None
+    return _read_nsstring(frame, process, attr_ptr, opts)
+
+
 def _on_secitem_entry(frame, bp_loc, extra_args, internal_dict):
     global _secitem_count
     if _done:
         return False
 
     try:
+        query_ptr = _arg(frame, 0)
         result_out_ptr = _arg(frame, 1)
+        service = _query_service_name(frame, query_ptr)
+
+        # Only track the two Find My keychain services
+        if service not in ("FMIPDataManager", "FMFDataManager"):
+            return False
+
         lr_raw = _entry_return_address(frame)
-        _log(f"  🔔  SecItemCopyMatching hit: result_out=0x{result_out_ptr:x} retaddr=0x{lr_raw:x}")
+        _log(f"  🔔  SecItemCopyMatching [{service}]: result_out=0x{result_out_ptr:x} retaddr=0x{lr_raw:x}")
         lr = _strip_pac(frame, lr_raw)
 
         if not result_out_ptr or not lr:
@@ -141,6 +168,7 @@ def _on_secitem_entry(frame, bp_loc, extra_args, internal_dict):
         _pending_returns[lr].append({
             "result_out_ptr": result_out_ptr,
             "index": idx,
+            "service": service,
         })
     except Exception as e:
         _log(f"  ⚠️  entry handler exception: {e}")


### PR DESCRIPTION
## Summary

On a fresh Apple Silicon Mac, `./extract.sh` hung: LocalStorage never saved, and FindMy got stuck under lldb until killed.

Two causes:

1. **lldb quit too early** — batch mode used `-o c` then `-o quit`. When multiple threads hit `sqlite3_key_v2` at once, the first stop that wasn't auto-continued caused `quit` to run and kill the session before the key was written. The FindMy session then waited forever.
2. **Too many keychain breakpoints** — every `SecItemCopyMatching` call got a return breakpoint. FindMy hits that constantly, so the debugger flooded and never captured FMF/FMIP.

Also, if looking up the DB path via `sqlite3_db_filename` failed, a valid 32-byte key was thrown away.

### Changes
- Wait for the key files (with a timeout) instead of relying on `-o quit`
- Only break on FMF/FMIP keychain services
- If path lookup fails, save a LocalStorage candidate and keep it after verification succeeds